### PR TITLE
Create new pages with actions and modals

### DIFF
--- a/days.php
+++ b/days.php
@@ -1,0 +1,204 @@
+<?php
+include 'connect.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+	$action = $_POST['action'] ?? '';
+	switch ($action) {
+		case 'add':
+			$name = trim($_POST['name'] ?? '');
+			if ($name === '') { echo "<script>alert('Please provide a name.');</script>"; break; }
+			$check = $conn->prepare('SELECT id FROM days WHERE name = ?');
+			$check->bind_param('s', $name);
+			$check->execute();
+			if ($check->get_result()->num_rows > 0) { $check->close(); echo "<script>alert('Day already exists.');</script>"; break; }
+			$check->close();
+			$stmt = $conn->prepare('INSERT INTO days (name) VALUES (?)');
+			$stmt->bind_param('s', $name);
+			if ($stmt->execute()) { echo "<script>alert('Day added!'); window.location.href='days.php';</script>"; } else { echo 'Error: ' . $stmt->error; }
+			$stmt->close();
+			break;
+		case 'update':
+			$id = intval($_POST['id'] ?? 0);
+			$name = trim($_POST['name'] ?? '');
+			if ($id <= 0 || $name === '') { echo "<script>alert('Invalid values.');</script>"; break; }
+			$check = $conn->prepare('SELECT id FROM days WHERE name = ? AND id != ?');
+			$check->bind_param('si', $name, $id);
+			$check->execute();
+			if ($check->get_result()->num_rows > 0) { $check->close(); echo "<script>alert('Another day with this name exists.');</script>"; break; }
+			$check->close();
+			$stmt = $conn->prepare('UPDATE days SET name = ? WHERE id = ?');
+			$stmt->bind_param('si', $name, $id);
+			if ($stmt->execute()) { echo "<script>alert('Day updated!'); window.location.href='days.php';</script>"; } else { echo 'Error: ' . $stmt->error; }
+			$stmt->close();
+			break;
+		case 'delete':
+			$id = intval($_POST['id'] ?? 0);
+			if ($id <= 0) { echo "<script>alert('Invalid day.');</script>"; break; }
+			$dep = $conn->prepare('SELECT COUNT(*) AS cnt FROM timetable WHERE day_id = ?');
+			$dep->bind_param('i', $id);
+			$dep->execute();
+			$cnt = $dep->get_result()->fetch_assoc()['cnt'] ?? 0;
+			$dep->close();
+			if ($cnt > 0) { echo "<script>alert('Cannot delete: referenced by timetable.');</script>"; break; }
+			$stmt = $conn->prepare('DELETE FROM days WHERE id = ?');
+			$stmt->bind_param('i', $id);
+			if ($stmt->execute()) { echo "<script>alert('Day deleted!'); window.location.href='days.php';</script>"; } else { echo 'Error: ' . $stmt->error; }
+			$stmt->close();
+			break;
+	}
+}
+
+$days = [];
+$res = $conn->query('SELECT * FROM days ORDER BY id');
+if ($res) { while ($r = $res->fetch_assoc()) { $days[] = $r; } }
+?>
+<?php $pageTitle = 'Days'; include 'includes/header.php'; include 'includes/sidebar.php'; ?>
+
+<div class="main-content" id="mainContent">
+	<h2>Days</h2>
+	<div class="d-flex justify-content-between align-items-center mb-4">
+		<div class="input-group" style="width: 300px;">
+			<span class="input-group-text"><i class="fas fa-search"></i></span>
+			<input type="text" class="form-control" id="searchInput" placeholder="Search days...">
+		</div>
+		<div>
+			<button class="btn btn-primary me-2" data-bs-toggle="modal" data-bs-target="#importModal">Import</button>
+			<button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#dayModal"><i class="fas fa-plus me-2"></i>Add</button>
+		</div>
+	</div>
+
+	<div class="table-container">
+		<div class="table-header"><h4><i class="fas fa-calendar-day me-2"></i>Existing Days</h4></div>
+		<div class="table-responsive">
+			<table class="table" id="daysTable">
+				<thead><tr><th>ID</th><th>Name</th><th>Actions</th></tr></thead>
+				<tbody>
+					<?php if (empty($days)): ?>
+						<tr><td colspan="3" class="text-center">No days found</td></tr>
+					<?php else: foreach ($days as $d): ?>
+						<tr>
+							<td><span class="badge bg-primary"><?php echo (int)$d['id']; ?></span></td>
+							<td><strong><?php echo htmlspecialchars($d['name']); ?></strong></td>
+							<td>
+								<button class="btn btn-sm btn-outline-primary" onclick="editDay(<?php echo (int)$d['id']; ?>, '<?php echo htmlspecialchars($d['name'], ENT_QUOTES); ?>')">Edit</button>
+								<button class="btn btn-sm btn-outline-danger" onclick="deleteDay(<?php echo (int)$d['id']; ?>, '<?php echo htmlspecialchars($d['name'], ENT_QUOTES); ?>')">Delete</button>
+							</td>
+						</tr>
+					<?php endforeach; endif; ?>
+				</tbody>
+			</table>
+		</div>
+	</div>
+</div>
+
+<!-- Add/Edit Modal -->
+<div class="modal fade" id="dayModal" tabindex="-1" aria-labelledby="dayModalLabel" aria-hidden="true">
+	<div class="modal-dialog">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h5 class="modal-title" id="dayModalLabel">Add Day</h5>
+				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+			</div>
+			<form method="POST" id="dayForm">
+				<input type="hidden" name="action" id="dayAction" value="add">
+				<input type="hidden" name="id" id="dayId">
+				<div class="modal-body">
+					<div class="mb-3">
+						<label for="dayName" class="form-label">Name</label>
+						<input type="text" class="form-control" id="dayName" name="name" placeholder="e.g., Monday" required>
+					</div>
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+					<button type="submit" class="btn btn-primary">Save</button>
+				</div>
+			</form>
+		</div>
+	</div>
+</div>
+
+<!-- Import Modal -->
+<div class="modal fade" id="importModal" tabindex="-1" aria-labelledby="importModalLabel" aria-hidden="true">
+	<div class="modal-dialog">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h5 class="modal-title" id="importModalLabel">Import Days</h5>
+				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+			</div>
+			<div class="modal-body">
+				<form action="import_days.php" method="POST" enctype="multipart/form-data">
+					<div class="mb-3">
+						<label for="daysFile" class="form-label">Choose Excel File</label>
+						<input type="file" class="form-control" id="daysFile" name="file" required accept=".xls,.xlsx">
+					</div>
+					<button type="submit" class="btn btn-primary">Upload</button>
+				</form>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="footer" id="footer">&copy; 2025 University Timetable Generator</div>
+
+<button id="backToTop" style="position: fixed; bottom: 30px; right: 30px; display:none; background: rgba(128, 0, 32, 0.7); border: none; width: 50px; height: 50px; border-radius: 50%;">
+	<svg width="50" height="50" viewBox="0 0 50 50">
+		<circle id="progressCircle" cx="25" cy="25" r="20" fill="none" stroke="#FFD700" stroke-width="4" stroke-dasharray="126" stroke-dashoffset="126"></circle>
+	</svg>
+	<i class="fas fa-arrow-up arrow-icon" style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);color:#FFD700;font-size:1.5rem;"></i>
+</button>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.2/js/bootstrap.bundle.min.js"></script>
+<script>
+function editDay(id, name) {
+	document.getElementById('dayModalLabel').textContent = 'Edit Day';
+	document.getElementById('dayAction').value = 'update';
+	document.getElementById('dayId').value = id;
+	document.getElementById('dayName').value = name;
+	new bootstrap.Modal(document.getElementById('dayModal')).show();
+}
+function deleteDay(id, name) {
+	if (!confirm(`Delete day "${name}"?`)) return;
+	const form = document.createElement('form');
+	form.method = 'POST';
+	form.action = 'days.php';
+	form.innerHTML = '<input type="hidden" name="action" value="delete">' +
+		'<input type="hidden" name="id" value="' + id + '">';
+	document.body.appendChild(form);
+	form.submit();
+}
+document.getElementById('searchInput')?.addEventListener('input', function() {
+	const q = this.value.toLowerCase();
+	document.querySelectorAll('#daysTable tbody tr').forEach(tr => {
+		tr.style.display = tr.textContent.toLowerCase().includes(q) ? '' : 'none';
+	});
+});
+
+// Sidebar toggle
+document.getElementById('sidebarToggle')?.addEventListener('click', function() {
+	const sidebar = document.getElementById('sidebar');
+	const mainContent = document.getElementById('mainContent');
+	const footer = document.getElementById('footer');
+	if (sidebar.classList.contains('collapsed')) { sidebar.classList.remove('collapsed'); mainContent.classList.remove('collapsed'); footer.classList.remove('collapsed'); }
+	else { sidebar.classList.add('collapsed'); mainContent.classList.add('collapsed'); footer.classList.add('collapsed'); }
+});
+
+// Back to top
+const backToTopButton = document.getElementById('backToTop');
+const progressCircle = document.getElementById('progressCircle');
+const circumference = 2 * Math.PI * 20;
+progressCircle.style.strokeDasharray = circumference;
+progressCircle.style.strokeDashoffset = circumference;
+window.addEventListener('scroll', function() {
+	const scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
+	backToTopButton.style.display = scrollTop > 100 ? 'block' : 'none';
+	const scrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+	const scrollPercentage = scrollTop / scrollHeight;
+	const offset = circumference - (scrollPercentage * circumference);
+	progressCircle.style.strokeDashoffset = offset;
+});
+backToTopButton.addEventListener('click', function() { window.scrollTo({ top: 0, behavior: 'smooth' }); });
+</script>
+
+</body>
+</html>
+

--- a/import_days.php
+++ b/import_days.php
@@ -1,0 +1,47 @@
+<?php
+require 'vendor/autoload.php';
+use PhpOffice\PhpSpreadsheet\IOFactory;
+
+include 'connect.php';
+
+if (!isset($_FILES['file']) || $_FILES['file']['error'] !== UPLOAD_ERR_OK) {
+	die('Error: No file uploaded or upload error occurred.');
+}
+
+$file = $_FILES['file'];
+$ext = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
+if (!in_array($ext, ['xls','xlsx'])) { die('Error: Only Excel files (.xls, .xlsx) are allowed.'); }
+
+try {
+	$spreadsheet = IOFactory::load($file['tmp_name']);
+	$worksheet = $spreadsheet->getActiveSheet();
+	$rows = $worksheet->toArray();
+	if (!$rows || count($rows) < 2) { die('Error: No data rows found.'); }
+	array_shift($rows); // headers, assume first column Name
+	$success = 0; $skipped = 0;
+	foreach ($rows as $row) {
+		if (!array_filter($row)) continue;
+		$name = trim((string)($row[0] ?? ''));
+		if ($name === '') { $skipped++; continue; }
+		$check = $conn->prepare('SELECT id FROM days WHERE name = ?');
+		$check->bind_param('s', $name);
+		$check->execute();
+		if ($check->get_result()->num_rows > 0) { $check->close(); $skipped++; continue; }
+		$check->close();
+		$stmt = $conn->prepare('INSERT INTO days (name) VALUES (?)');
+		if (!$stmt) { $skipped++; continue; }
+		$stmt->bind_param('s', $name);
+		if ($stmt->execute()) { $success++; } else { $skipped++; }
+		$stmt->close();
+	}
+	echo "<h2>Import Results</h2>";
+	echo "<p><strong>Successfully imported:</strong> {$success} days</p>";
+	echo "<p><strong>Errors/Skipped:</strong> {$skipped}</p>";
+	echo "<p><a href='days.php'>Back to Days</a></p>";
+} catch (Exception $e) {
+	die('Error processing file: ' . $e->getMessage());
+}
+
+$conn->close();
+?>
+

--- a/import_levels.php
+++ b/import_levels.php
@@ -1,0 +1,58 @@
+<?php
+require 'vendor/autoload.php';
+use PhpOffice\PhpSpreadsheet\IOFactory;
+
+include 'connect.php';
+
+if (!isset($_FILES['file']) || $_FILES['file']['error'] !== UPLOAD_ERR_OK) {
+	die('Error: No file uploaded or upload error occurred.');
+}
+
+$file = $_FILES['file'];
+$fileName = $file['name'];
+$tmp = $file['tmp_name'];
+$ext = strtolower(pathinfo($fileName, PATHINFO_EXTENSION));
+if (!in_array($ext, ['xls','xlsx'])) {
+	die('Error: Only Excel files (.xls, .xlsx) are allowed.');
+}
+
+try {
+	$spreadsheet = IOFactory::load($tmp);
+	$worksheet = $spreadsheet->getActiveSheet();
+	$rows = $worksheet->toArray();
+	if (!$rows || count($rows) < 2) {
+		die('Error: No data rows found.');
+	}
+	// Assume first row is header with columns: Name, Year Number
+	array_shift($rows);
+	$success = 0;
+	$errors = 0;
+	foreach ($rows as $index => $row) {
+		if (!array_filter($row)) continue; // skip empty
+		$name = trim((string)($row[0] ?? ''));
+		$yearNumberRaw = $row[1] ?? '';
+		$yearNumber = is_numeric($yearNumberRaw) ? (int)$yearNumberRaw : (int)preg_replace('/[^0-9]/','',$yearNumberRaw);
+		if ($name === '' || $yearNumber <= 0) { $errors++; continue; }
+		// Check duplicates by year_number or name
+		$check = $conn->prepare('SELECT id FROM levels WHERE year_number = ? OR name = ?');
+		$check->bind_param('is', $yearNumber, $name);
+		$check->execute();
+		if ($check->get_result()->num_rows > 0) { $check->close(); continue; }
+		$check->close();
+		$stmt = $conn->prepare('INSERT INTO levels (name, year_number) VALUES (?, ?)');
+		if (!$stmt) { $errors++; continue; }
+		$stmt->bind_param('si', $name, $yearNumber);
+		if ($stmt->execute()) { $success++; } else { $errors++; }
+		$stmt->close();
+	}
+	echo "<h2>Import Results</h2>";
+	echo "<p><strong>Successfully imported:</strong> {$success} levels</p>";
+	echo "<p><strong>Errors/Skipped:</strong> {$errors}</p>";
+	echo "<p><a href='levels.php'>Back to Levels</a></p>";
+} catch (Exception $e) {
+	die('Error processing file: ' . $e->getMessage());
+}
+
+$conn->close();
+?>
+

--- a/import_session_types.php
+++ b/import_session_types.php
@@ -1,0 +1,47 @@
+<?php
+require 'vendor/autoload.php';
+use PhpOffice\PhpSpreadsheet\IOFactory;
+
+include 'connect.php';
+
+if (!isset($_FILES['file']) || $_FILES['file']['error'] !== UPLOAD_ERR_OK) {
+	die('Error: No file uploaded or upload error occurred.');
+}
+
+$file = $_FILES['file'];
+$ext = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
+if (!in_array($ext, ['xls','xlsx'])) { die('Error: Only Excel files (.xls, .xlsx) are allowed.'); }
+
+try {
+	$spreadsheet = IOFactory::load($file['tmp_name']);
+	$worksheet = $spreadsheet->getActiveSheet();
+	$rows = $worksheet->toArray();
+	if (!$rows || count($rows) < 2) { die('Error: No data rows found.'); }
+	array_shift($rows); // headers, assume first column Name
+	$success = 0; $skipped = 0;
+	foreach ($rows as $row) {
+		if (!array_filter($row)) continue;
+		$name = trim((string)($row[0] ?? ''));
+		if ($name === '') { $skipped++; continue; }
+		$check = $conn->prepare('SELECT id FROM session_types WHERE name = ?');
+		$check->bind_param('s', $name);
+		$check->execute();
+		if ($check->get_result()->num_rows > 0) { $check->close(); $skipped++; continue; }
+		$check->close();
+		$stmt = $conn->prepare('INSERT INTO session_types (name) VALUES (?)');
+		if (!$stmt) { $skipped++; continue; }
+		$stmt->bind_param('s', $name);
+		if ($stmt->execute()) { $success++; } else { $skipped++; }
+		$stmt->close();
+	}
+	echo "<h2>Import Results</h2>";
+	echo "<p><strong>Successfully imported:</strong> {$success} session types</p>";
+	echo "<p><strong>Errors/Skipped:</strong> {$skipped}</p>";
+	echo "<p><a href='session_types.php'>Back to Session Types</a></p>";
+} catch (Exception $e) {
+	die('Error processing file: ' . $e->getMessage());
+}
+
+$conn->close();
+?>
+

--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -6,6 +6,8 @@
     <a href="view_timetable.php" class="<?= ($currentPage == 'view_timetable.php') ? 'active' : '' ?>"><i class="fas fa-table me-2"></i>View Timetable</a>
     <a href="timetable_lecturers.php" class="<?= ($currentPage == 'timetable_lecturers.php') ? 'active' : '' ?>"><i class="fas fa-users-cog me-2"></i>Co-Teaching</a>
     <a href="adddepartmentform.php" class="<?= ($currentPage == 'adddepartmentform.php') ? 'active' : '' ?>"><i class="fas fa-building me-2"></i>Departments</a>
+    <a href="programs.php" class="<?= ($currentPage == 'programs.php') ? 'active' : '' ?>"><i class="fas fa-graduation-cap me-2"></i>Programs</a>
+    <a href="levels.php" class="<?= ($currentPage == 'levels.php') ? 'active' : '' ?>"><i class="fas fa-layer-group me-2"></i>Levels</a>
     <a href="sessions.php" class="<?= ($currentPage == 'sessions.php') ? 'active' : '' ?>"><i class="fas fa-clock me-2"></i>Sessions</a>
     <a href="semesters.php" class="<?= ($currentPage == 'semesters.php') ? 'active' : '' ?>"><i class="fas fa-calendar me-2"></i>Semesters</a>
     <a href="classes.php" class="<?= ($currentPage == 'classes.php') ? 'active' : '' ?>"><i class="fas fa-users me-2"></i>Classes</a>
@@ -17,6 +19,8 @@
     <a href="lecturer_courses.php" class="<?= ($currentPage == 'lecturer_courses.php') ? 'active' : '' ?>"><i class="fas fa-link me-2"></i>Lecturer-Courses</a>
     <a href="lecturer_session_availability.php" class="<?= ($currentPage == 'lecturer_session_availability.php') ? 'active' : '' ?>"><i class="fas fa-link me-2"></i>Lecturer Sessions</a>
     <a href="course_session_availability.php" class="<?= ($currentPage == 'course_session_availability.php') ? 'active' : '' ?>"><i class="fas fa-link me-2"></i>Course Sessions</a>
+    <a href="session_types.php" class="<?= ($currentPage == 'session_types.php') ? 'active' : '' ?>"><i class="fas fa-tags me-2"></i>Session Types</a>
+    <a href="days.php" class="<?= ($currentPage == 'days.php') ? 'active' : '' ?>"><i class="fas fa-calendar-day me-2"></i>Days</a>
   </div>
 </div>
 

--- a/levels.php
+++ b/levels.php
@@ -1,0 +1,281 @@
+<?php
+include 'connect.php';
+
+// Handle form submissions
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+	$action = $_POST['action'] ?? '';
+	switch ($action) {
+		case 'add':
+			$name = trim($_POST['name'] ?? '');
+			$yearNumber = intval($_POST['year_number'] ?? 0);
+			if ($name === '' || $yearNumber <= 0) {
+				echo "<script>alert('Please provide a valid name and year number.');</script>";
+				break;
+			}
+			// Prevent duplicates by year_number or name
+			$checkSql = "SELECT id FROM levels WHERE year_number = ? OR name = ?";
+			$checkStmt = $conn->prepare($checkSql);
+			$checkStmt->bind_param('is', $yearNumber, $name);
+			$checkStmt->execute();
+			$exists = $checkStmt->get_result()->num_rows > 0;
+			$checkStmt->close();
+			if ($exists) {
+				echo "<script>alert('A level with this name or year already exists.');</script>";
+				break;
+			}
+			$sql = "INSERT INTO levels (name, year_number) VALUES (?, ?)";
+			$stmt = $conn->prepare($sql);
+			$stmt->bind_param('si', $name, $yearNumber);
+			if ($stmt->execute()) {
+				echo "<script>alert('Level added successfully!'); window.location.href='levels.php';</script>";
+			} else {
+				echo "Error: " . $stmt->error;
+			}
+			$stmt->close();
+			break;
+
+		case 'update':
+			$id = intval($_POST['id'] ?? 0);
+			$name = trim($_POST['name'] ?? '');
+			$yearNumber = intval($_POST['year_number'] ?? 0);
+			if ($id <= 0 || $name === '' || $yearNumber <= 0) {
+				echo "<script>alert('Please provide valid values.');</script>";
+				break;
+			}
+			$checkSql = "SELECT id FROM levels WHERE (year_number = ? OR name = ?) AND id != ?";
+			$checkStmt = $conn->prepare($checkSql);
+			$checkStmt->bind_param('isi', $yearNumber, $name, $id);
+			$checkStmt->execute();
+			$exists = $checkStmt->get_result()->num_rows > 0;
+			$checkStmt->close();
+			if ($exists) {
+				echo "<script>alert('Another level with this name or year already exists.');</script>";
+				break;
+			}
+			$sql = "UPDATE levels SET name = ?, year_number = ? WHERE id = ?";
+			$stmt = $conn->prepare($sql);
+			$stmt->bind_param('sii', $name, $yearNumber, $id);
+			if ($stmt->execute()) {
+				echo "<script>alert('Level updated successfully!'); window.location.href='levels.php';</script>";
+			} else {
+				echo "Error: " . $stmt->error;
+			}
+			$stmt->close();
+			break;
+
+		case 'delete':
+			$id = intval($_POST['id'] ?? 0);
+			if ($id <= 0) { echo "<script>alert('Invalid level.');</script>"; break; }
+			// courses.level stores the numeric year (1..n), not the level id
+			$yrStmt = $conn->prepare('SELECT year_number FROM levels WHERE id = ?');
+			$yrStmt->bind_param('i', $id);
+			$yrStmt->execute();
+			$row = $yrStmt->get_result()->fetch_assoc();
+			$yrStmt->close();
+			if (!$row) { echo "<script>alert('Level not found.');</script>"; break; }
+			$yearNumber = intval($row['year_number']);
+			$checkSql = "SELECT COUNT(*) AS cnt FROM courses WHERE level = ?";
+			$checkStmt = $conn->prepare($checkSql);
+			$checkStmt->bind_param('i', $yearNumber);
+			$checkStmt->execute();
+			$cnt = $checkStmt->get_result()->fetch_assoc()['cnt'] ?? 0;
+			$checkStmt->close();
+			if ($cnt > 0) {
+				echo "<script>alert('Cannot delete: Courses reference this level year.');</script>";
+				break;
+			}
+			$stmt = $conn->prepare("DELETE FROM levels WHERE id = ?");
+			$stmt->bind_param('i', $id);
+			if ($stmt->execute()) {
+				echo "<script>alert('Level deleted successfully!'); window.location.href='levels.php';</script>";
+			} else {
+				echo "Error: " . $stmt->error;
+			}
+			$stmt->close();
+			break;
+	}
+}
+
+// Fetch levels
+$levels = [];
+$res = $conn->query("SELECT * FROM levels ORDER BY year_number");
+if ($res) {
+	while ($row = $res->fetch_assoc()) { $levels[] = $row; }
+}
+?>
+<?php $pageTitle = 'Manage Levels'; include 'includes/header.php'; include 'includes/sidebar.php'; ?>
+
+<div class="main-content" id="mainContent">
+	<h2>Manage Levels</h2>
+	<div class="d-flex justify-content-between align-items-center mb-4">
+		<div class="input-group" style="width: 300px;">
+			<span class="input-group-text"><i class="fas fa-search"></i></span>
+			<input type="text" class="form-control" id="searchInput" placeholder="Search levels...">
+		</div>
+		<div>
+			<button class="btn btn-primary me-2" data-bs-toggle="modal" data-bs-target="#importModal">Import</button>
+			<button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#levelModal"><i class="fas fa-plus me-2"></i>Add Level</button>
+		</div>
+	</div>
+
+	<div class="table-container">
+		<div class="table-header">
+			<h4><i class="fas fa-layer-group me-2"></i>Existing Levels</h4>
+		</div>
+		<div class="table-responsive">
+			<table class="table" id="levelsTable">
+				<thead>
+					<tr>
+						<th>Name</th>
+						<th>Year Number</th>
+						<th>Actions</th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php if (empty($levels)): ?>
+						<tr><td colspan="3" class="text-center">No levels found</td></tr>
+					<?php else: foreach ($levels as $level): ?>
+						<tr>
+							<td><strong><?php echo htmlspecialchars($level['name']); ?></strong></td>
+							<td><span class="badge bg-primary"><?php echo (int)$level['year_number']; ?></span></td>
+							<td>
+								<button class="btn btn-sm btn-outline-primary" onclick="editLevel(<?php echo (int)$level['id']; ?>, '<?php echo htmlspecialchars($level['name'], ENT_QUOTES); ?>', <?php echo (int)$level['year_number']; ?>)">Edit</button>
+								<button class="btn btn-sm btn-outline-danger" onclick="deleteLevel(<?php echo (int)$level['id']; ?>, '<?php echo htmlspecialchars($level['name'], ENT_QUOTES); ?>')">Delete</button>
+							</td>
+						</tr>
+					<?php endforeach; endif; ?>
+				</tbody>
+			</table>
+		</div>
+	</div>
+</div>
+
+<!-- Add/Edit Modal -->
+<div class="modal fade" id="levelModal" tabindex="-1" aria-labelledby="levelModalLabel" aria-hidden="true">
+	<div class="modal-dialog">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h5 class="modal-title" id="levelModalLabel">Add Level</h5>
+				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+			</div>
+			<form method="POST" id="levelForm">
+				<input type="hidden" name="action" id="levelAction" value="add">
+				<input type="hidden" name="id" id="levelId">
+				<div class="modal-body">
+					<div class="mb-3">
+						<label for="levelName" class="form-label">Name</label>
+						<input type="text" class="form-control" id="levelName" name="name" placeholder="e.g., Level 100" required>
+					</div>
+					<div class="mb-3">
+						<label for="yearNumber" class="form-label">Year Number</label>
+						<input type="number" class="form-control" id="yearNumber" name="year_number" placeholder="e.g., 1" required min="1">
+					</div>
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+					<button type="submit" class="btn btn-primary">Save</button>
+				</div>
+			</form>
+		</div>
+	</div>
+</div>
+
+<!-- Import Modal -->
+<div class="modal fade" id="importModal" tabindex="-1" aria-labelledby="importModalLabel" aria-hidden="true">
+	<div class="modal-dialog">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h5 class="modal-title" id="importModalLabel">Import Levels</h5>
+				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+			</div>
+			<div class="modal-body">
+				<form action="import_levels.php" method="POST" enctype="multipart/form-data">
+					<div class="mb-3">
+						<label for="levelsFile" class="form-label">Choose Excel File</label>
+						<input type="file" class="form-control" id="levelsFile" name="file" required accept=".xls,.xlsx">
+					</div>
+					<button type="submit" class="btn btn-primary">Upload</button>
+				</form>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="footer" id="footer">&copy; 2025 University Timetable Generator</div>
+
+<button id="backToTop" style="position: fixed; bottom: 30px; right: 30px; display:none; background: rgba(128, 0, 32, 0.7); border: none; width: 50px; height: 50px; border-radius: 50%;">
+	<svg width="50" height="50" viewBox="0 0 50 50">
+		<circle id="progressCircle" cx="25" cy="25" r="20" fill="none" stroke="#FFD700" stroke-width="4" stroke-dasharray="126" stroke-dashoffset="126"></circle>
+	</svg>
+	<i class="fas fa-arrow-up arrow-icon" style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);color:#FFD700;font-size:1.5rem;"></i>
+</button>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.2/js/bootstrap.bundle.min.js"></script>
+<script>
+// Sidebar toggle behavior consistent with header include
+document.getElementById('sidebarToggle')?.addEventListener('click', function() {
+	const sidebar = document.getElementById('sidebar');
+	const mainContent = document.getElementById('mainContent');
+	const footer = document.getElementById('footer');
+	if (sidebar.classList.contains('collapsed')) {
+		sidebar.classList.remove('collapsed');
+		mainContent.classList.remove('collapsed');
+		footer.classList.remove('collapsed');
+	} else {
+		sidebar.classList.add('collapsed');
+		mainContent.classList.add('collapsed');
+		footer.classList.add('collapsed');
+	}
+});
+
+// Simple search filter
+document.getElementById('searchInput')?.addEventListener('input', function() {
+	const q = this.value.toLowerCase();
+	document.querySelectorAll('#levelsTable tbody tr').forEach(tr => {
+		const text = tr.textContent.toLowerCase();
+		tr.style.display = text.includes(q) ? '' : 'none';
+	});
+});
+
+// Edit and delete helpers
+function editLevel(id, name, yearNumber) {
+	document.getElementById('levelModalLabel').textContent = 'Edit Level';
+	document.getElementById('levelAction').value = 'update';
+	document.getElementById('levelId').value = id;
+	document.getElementById('levelName').value = name;
+	document.getElementById('yearNumber').value = yearNumber;
+	const modal = new bootstrap.Modal(document.getElementById('levelModal'));
+	modal.show();
+}
+
+function deleteLevel(id, name) {
+	if (!confirm(`Delete level "${name}"? This cannot be undone.`)) return;
+	const form = document.createElement('form');
+	form.method = 'POST';
+	form.action = 'levels.php';
+	form.innerHTML = '<input type="hidden" name="action" value="delete">' +
+		'<input type="hidden" name="id" value="' + id + '">';
+	document.body.appendChild(form);
+	form.submit();
+}
+
+// Back to top behavior
+const backToTopButton = document.getElementById('backToTop');
+const progressCircle = document.getElementById('progressCircle');
+const circumference = 2 * Math.PI * 20;
+progressCircle.style.strokeDasharray = circumference;
+progressCircle.style.strokeDashoffset = circumference;
+window.addEventListener('scroll', function() {
+	const scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
+	backToTopButton.style.display = scrollTop > 100 ? 'block' : 'none';
+	const scrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+	const scrollPercentage = scrollTop / scrollHeight;
+	const offset = circumference - (scrollPercentage * circumference);
+	progressCircle.style.strokeDashoffset = offset;
+});
+backToTopButton.addEventListener('click', function() { window.scrollTo({ top: 0, behavior: 'smooth' }); });
+</script>
+
+</body>
+</html>
+

--- a/session_types.php
+++ b/session_types.php
@@ -1,0 +1,208 @@
+<?php
+include 'connect.php';
+
+// Handle actions
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+	$action = $_POST['action'] ?? '';
+	switch ($action) {
+		case 'add':
+			$name = trim($_POST['name'] ?? '');
+			if ($name === '') { echo "<script>alert('Please provide a name.');</script>"; break; }
+			$check = $conn->prepare('SELECT id FROM session_types WHERE name = ?');
+			$check->bind_param('s', $name);
+			$check->execute();
+			if ($check->get_result()->num_rows > 0) { $check->close(); echo "<script>alert('Session type already exists.');</script>"; break; }
+			$check->close();
+			$stmt = $conn->prepare('INSERT INTO session_types (name) VALUES (?)');
+			$stmt->bind_param('s', $name);
+			if ($stmt->execute()) { echo "<script>alert('Session type added!'); window.location.href='session_types.php';</script>"; }
+			else { echo 'Error: ' . $stmt->error; }
+			$stmt->close();
+			break;
+		case 'update':
+			$id = intval($_POST['id'] ?? 0);
+			$name = trim($_POST['name'] ?? '');
+			if ($id <= 0 || $name === '') { echo "<script>alert('Invalid values.');</script>"; break; }
+			$check = $conn->prepare('SELECT id FROM session_types WHERE name = ? AND id != ?');
+			$check->bind_param('si', $name, $id);
+			$check->execute();
+			if ($check->get_result()->num_rows > 0) { $check->close(); echo "<script>alert('Another session type with this name exists.');</script>"; break; }
+			$check->close();
+			$stmt = $conn->prepare('UPDATE session_types SET name = ? WHERE id = ?');
+			$stmt->bind_param('si', $name, $id);
+			if ($stmt->execute()) { echo "<script>alert('Session type updated!'); window.location.href='session_types.php';</script>"; }
+			else { echo 'Error: ' . $stmt->error; }
+			$stmt->close();
+			break;
+		case 'delete':
+			$id = intval($_POST['id'] ?? 0);
+			if ($id <= 0) { echo "<script>alert('Invalid session type.');</script>"; break; }
+			$dep = $conn->prepare('SELECT COUNT(*) AS cnt FROM timetable WHERE session_type_id = ?');
+			$dep->bind_param('i', $id);
+			$dep->execute();
+			$cnt = $dep->get_result()->fetch_assoc()['cnt'] ?? 0;
+			$dep->close();
+			if ($cnt > 0) { echo "<script>alert('Cannot delete: referenced by timetable.');</script>"; break; }
+			$stmt = $conn->prepare('DELETE FROM session_types WHERE id = ?');
+			$stmt->bind_param('i', $id);
+			if ($stmt->execute()) { echo "<script>alert('Session type deleted!'); window.location.href='session_types.php';</script>"; }
+			else { echo 'Error: ' . $stmt->error; }
+			$stmt->close();
+			break;
+	}
+}
+
+// Fetch
+$types = [];
+$res = $conn->query('SELECT * FROM session_types ORDER BY name');
+if ($res) { while ($r = $res->fetch_assoc()) { $types[] = $r; } }
+?>
+<?php $pageTitle = 'Session Types'; include 'includes/header.php'; include 'includes/sidebar.php'; ?>
+
+<div class="main-content" id="mainContent">
+	<h2>Session Types</h2>
+	<div class="d-flex justify-content-between align-items-center mb-4">
+		<div class="input-group" style="width: 300px;">
+			<span class="input-group-text"><i class="fas fa-search"></i></span>
+			<input type="text" class="form-control" id="searchInput" placeholder="Search session types...">
+		</div>
+		<div>
+			<button class="btn btn-primary me-2" data-bs-toggle="modal" data-bs-target="#importModal">Import</button>
+			<button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#typeModal"><i class="fas fa-plus me-2"></i>Add</button>
+		</div>
+	</div>
+
+	<div class="table-container">
+		<div class="table-header"><h4><i class="fas fa-tags me-2"></i>Existing Session Types</h4></div>
+		<div class="table-responsive">
+			<table class="table" id="typesTable">
+				<thead><tr><th>Name</th><th>Actions</th></tr></thead>
+				<tbody>
+					<?php if (empty($types)): ?>
+						<tr><td colspan="2" class="text-center">No session types found</td></tr>
+					<?php else: foreach ($types as $t): ?>
+						<tr>
+							<td><strong><?php echo htmlspecialchars($t['name']); ?></strong></td>
+							<td>
+								<button class="btn btn-sm btn-outline-primary" onclick="editType(<?php echo (int)$t['id']; ?>, '<?php echo htmlspecialchars($t['name'], ENT_QUOTES); ?>')">Edit</button>
+								<button class="btn btn-sm btn-outline-danger" onclick="deleteType(<?php echo (int)$t['id']; ?>, '<?php echo htmlspecialchars($t['name'], ENT_QUOTES); ?>')">Delete</button>
+							</td>
+						</tr>
+					<?php endforeach; endif; ?>
+				</tbody>
+			</table>
+		</div>
+	</div>
+</div>
+
+<!-- Add/Edit Modal -->
+<div class="modal fade" id="typeModal" tabindex="-1" aria-labelledby="typeModalLabel" aria-hidden="true">
+	<div class="modal-dialog">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h5 class="modal-title" id="typeModalLabel">Add Session Type</h5>
+				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+			</div>
+			<form method="POST" id="typeForm">
+				<input type="hidden" name="action" id="typeAction" value="add">
+				<input type="hidden" name="id" id="typeId">
+				<div class="modal-body">
+					<div class="mb-3">
+						<label for="typeName" class="form-label">Name</label>
+						<input type="text" class="form-control" id="typeName" name="name" placeholder="e.g., Lecture" required>
+					</div>
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+					<button type="submit" class="btn btn-primary">Save</button>
+				</div>
+			</form>
+		</div>
+	</div>
+</div>
+
+<!-- Import Modal -->
+<div class="modal fade" id="importModal" tabindex="-1" aria-labelledby="importModalLabel" aria-hidden="true">
+	<div class="modal-dialog">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h5 class="modal-title" id="importModalLabel">Import Session Types</h5>
+				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+			</div>
+			<div class="modal-body">
+				<form action="import_session_types.php" method="POST" enctype="multipart/form-data">
+					<div class="mb-3">
+						<label for="typesFile" class="form-label">Choose Excel File</label>
+						<input type="file" class="form-control" id="typesFile" name="file" required accept=".xls,.xlsx">
+					</div>
+					<button type="submit" class="btn btn-primary">Upload</button>
+				</form>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="footer" id="footer">&copy; 2025 University Timetable Generator</div>
+
+<button id="backToTop" style="position: fixed; bottom: 30px; right: 30px; display:none; background: rgba(128, 0, 32, 0.7); border: none; width: 50px; height: 50px; border-radius: 50%;">
+	<svg width="50" height="50" viewBox="0 0 50 50">
+		<circle id="progressCircle" cx="25" cy="25" r="20" fill="none" stroke="#FFD700" stroke-width="4" stroke-dasharray="126" stroke-dashoffset="126"></circle>
+	</svg>
+	<i class="fas fa-arrow-up arrow-icon" style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);color:#FFD700;font-size:1.5rem;"></i>
+</button>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.2/js/bootstrap.bundle.min.js"></script>
+<script>
+function editType(id, name) {
+	document.getElementById('typeModalLabel').textContent = 'Edit Session Type';
+	document.getElementById('typeAction').value = 'update';
+	document.getElementById('typeId').value = id;
+	document.getElementById('typeName').value = name;
+	new bootstrap.Modal(document.getElementById('typeModal')).show();
+}
+function deleteType(id, name) {
+	if (!confirm(`Delete session type "${name}"?`)) return;
+	const form = document.createElement('form');
+	form.method = 'POST';
+	form.action = 'session_types.php';
+	form.innerHTML = '<input type="hidden" name="action" value="delete">' +
+		'<input type="hidden" name="id" value="' + id + '">';
+	document.body.appendChild(form);
+	form.submit();
+}
+document.getElementById('searchInput')?.addEventListener('input', function() {
+	const q = this.value.toLowerCase();
+	document.querySelectorAll('#typesTable tbody tr').forEach(tr => {
+		tr.style.display = tr.textContent.toLowerCase().includes(q) ? '' : 'none';
+	});
+});
+
+// Sidebar toggle
+document.getElementById('sidebarToggle')?.addEventListener('click', function() {
+	const sidebar = document.getElementById('sidebar');
+	const mainContent = document.getElementById('mainContent');
+	const footer = document.getElementById('footer');
+	if (sidebar.classList.contains('collapsed')) { sidebar.classList.remove('collapsed'); mainContent.classList.remove('collapsed'); footer.classList.remove('collapsed'); }
+	else { sidebar.classList.add('collapsed'); mainContent.classList.add('collapsed'); footer.classList.add('collapsed'); }
+});
+
+// Back to top
+const backToTopButton = document.getElementById('backToTop');
+const progressCircle = document.getElementById('progressCircle');
+const circumference = 2 * Math.PI * 20;
+progressCircle.style.strokeDasharray = circumference;
+progressCircle.style.strokeDashoffset = circumference;
+window.addEventListener('scroll', function() {
+	const scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
+	backToTopButton.style.display = scrollTop > 100 ? 'block' : 'none';
+	const scrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+	const scrollPercentage = scrollTop / scrollHeight;
+	const offset = circumference - (scrollPercentage * circumference);
+	progressCircle.style.strokeDashoffset = offset;
+});
+backToTopButton.addEventListener('click', function() { window.scrollTo({ top: 0, behavior: 'smooth' }); });
+</script>
+
+</body>
+</html>
+


### PR DESCRIPTION
Add management pages for Levels, Session Types, and Days with CRUD, import functionality, and sidebar links.

The deletion logic for levels.php was corrected to check `courses.level` (which stores the year number) instead of the `level_id` to prevent deleting levels that are still referenced by courses, ensuring data integrity.

---
<a href="https://cursor.com/background-agent?bcId=bc-49a62770-f31d-418d-b8ab-01ae9bb309f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-49a62770-f31d-418d-b8ab-01ae9bb309f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

