### PR TITLE
Debug room page update issue or exclude flash

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -171,17 +171,20 @@ if (!isset($current_stream_name) || $current_stream_name === '') {
     }
 }
 
-// Render any flash message (if included by pages)
-if (function_exists('flash_get')) {
+// Render any flash message (if included by pages), except on rooms.php per request
+$__current_script = basename($_SERVER['PHP_SELF'] ?? '');
+if ($__current_script !== 'rooms.php') {
+  if (function_exists('flash_get')) {
     $flash = flash_get();
     if ($flash) {
-        // Make available to the page templates; assign to the conventional variables
-        if (isset($flash['type']) && in_array($flash['type'], ['error', 'danger'])) {
-            $error_message = $flash['message'];
-        } else {
-            $success_message = $flash['message'];
-        }
+      // Make available to the page templates; assign to the conventional variables
+      if (isset($flash['type']) && in_array($flash['type'], ['error', 'danger'])) {
+        $error_message = $flash['message'];
+      } else {
+        $success_message = $flash['message'];
+      }
     }
+  }
 }
 
 // --- Helper function for counts (guard against redeclaration) ---

--- a/rooms.php
+++ b/rooms.php
@@ -342,12 +342,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         else { $_SESSION['success_message'] = $msg; }
         header('Location: rooms.php'); exit;
     }
-    if (isset($_POST['room_type'])) {
-        error_log("Raw room_type from POST: '" . $_POST['room_type'] . "'");
-        error_log("Raw room_type length: " . strlen($_POST['room_type']));
-        error_log("Raw room_type ASCII: " . implode(',', array_map('ord', str_split($_POST['room_type']))));
-    }
-    
     // Single add
     } elseif ($action === 'add') {
         // Debug: Log all POST data
@@ -1281,7 +1275,7 @@ function editRoom(id, name, buildingId, roomType, capacity, isActive) {
         'seminar_room': 'Seminar Room',
         'auditorium': 'Auditorium'
     };
-    editRoomType.value = roomTypeMappings[roomType] || 'Classroom';
+    editRoomType.value = roomTypeMappings[roomType] || roomType || 'Classroom';
 
 
 


### PR DESCRIPTION
Fix `rooms.php` update issue by correcting POST branching, improving edit modal room type preselection, and excluding flash messages.

The page refresh issue on `rooms.php` was caused by a debug block breaking the POST `elseif` chain, preventing update handlers from executing. The edit modal's room type preselection was also improved to correctly map database values. Flash message exclusion was added as a requested fallback.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef0401f1-0519-403a-bd0f-eef9a2d6ada6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ef0401f1-0519-403a-bd0f-eef9a2d6ada6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

